### PR TITLE
Piece Promotion 

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465934, g: 0.49642956, b: 0.5748249, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -198,6 +198,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 3, y: 5}
   currentPosition: {x: 3, y: 5}
@@ -290,6 +292,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 4, y: 6}
   currentPosition: {x: 4, y: 6}
@@ -382,6 +386,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 5, y: 5}
   currentPosition: {x: 5, y: 5}
@@ -540,6 +546,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 5, y: 1}
   currentPosition: {x: 5, y: 1}
@@ -725,6 +733,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 3, y: 7}
   currentPosition: {x: 3, y: 7}
@@ -817,6 +827,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 3, y: 1}
   currentPosition: {x: 3, y: 1}
@@ -909,6 +921,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 2, y: 0}
   currentPosition: {x: 2, y: 0}
@@ -1001,6 +1015,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 1, y: 1}
   currentPosition: {x: 1, y: 1}
@@ -1093,6 +1109,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 0, y: 6}
   currentPosition: {x: 0, y: 6}
@@ -1185,6 +1203,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 7, y: 5}
   currentPosition: {x: 7, y: 5}
@@ -1277,6 +1297,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 4, y: 0}
   currentPosition: {x: 4, y: 0}
@@ -1369,6 +1391,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 4, y: 2}
   currentPosition: {x: 4, y: 2}
@@ -1461,6 +1485,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 6, y: 6}
   currentPosition: {x: 6, y: 6}
@@ -1553,6 +1579,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 0, y: 2}
   currentPosition: {x: 0, y: 2}
@@ -1645,6 +1673,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 7, y: 1}
   currentPosition: {x: 7, y: 1}
@@ -1737,6 +1767,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 1, y: 5}
   currentPosition: {x: 1, y: 5}
@@ -1908,6 +1940,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 2, y: 2}
   currentPosition: {x: 2, y: 2}
@@ -2093,6 +2127,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 2, y: 6}
   currentPosition: {x: 2, y: 6}
@@ -2318,6 +2354,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 0, y: 0}
   currentPosition: {x: 0, y: 0}
@@ -2413,6 +2451,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 373ef59e365ce42ceabf4f4a620db193, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   whiteIndicator: {fileID: 919132149155446097, guid: c7e6c1b37f30945f4ab79f707c864698, type: 3}
   blackIndicator: {fileID: 919132149155446097, guid: 7f417eb6e3afa45dd89fa4e13642eb32, type: 3}
 --- !u!1 &1435488966
@@ -2623,6 +2662,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 6, y: 2}
   currentPosition: {x: 6, y: 2}
@@ -2715,6 +2756,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 1, y: 7}
   currentPosition: {x: 1, y: 7}
@@ -2807,6 +2850,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: 1
   startPosition: {x: 6, y: 0}
   currentPosition: {x: 6, y: 0}
@@ -2899,6 +2944,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 7, y: 7}
   currentPosition: {x: 7, y: 7}
@@ -3442,6 +3489,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isActive: 0
+  isKing: 0
+  kingMesh: {fileID: 4300000, guid: 3c8aca86008d52b44a46685ec750df51, type: 3}
   color: -1
   startPosition: {x: 5, y: 7}
   currentPosition: {x: 5, y: 7}

--- a/Assets/Scripts/Game/Board.cs
+++ b/Assets/Scripts/Game/Board.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 public class Board : MonoBehaviour
 {
+  public Mesh kingMesh; 
   private Piece[,] layout;
   private List<Piece> pieces;
   private GameController controller;
@@ -73,6 +74,10 @@ public class Board : MonoBehaviour
       {
         case MoveOutcome.VALID:
           AlignPieceInSquare(piece);
+
+          if (piece.HasReachedOppositeEndOfBoard() && !piece.isKing)
+            piece.PromoteToKing();
+          
           FindAllValidMoves();
 
           if (IsGamePlayable())
@@ -92,8 +97,14 @@ public class Board : MonoBehaviour
 
         case MoveOutcome.CAPTURE:
           ClearAllMoves();
+
           AlignPieceInSquare(piece);
+
+          if (piece.HasReachedOppositeEndOfBoard() && !piece.isKing)
+            piece.PromoteToKing();
+
           FindValidMoves(piece);
+
           // If not more captures available, end turn
           if (!piece.HasCaptureMoves())
           {
@@ -125,6 +136,7 @@ public class Board : MonoBehaviour
         piece.previousPosition = piece.startPosition;
         piece.moveDestinations = new List<PieceDestination>();
         piece.captureDestinations = new List<PieceDestination>();
+        piece.kingMesh = kingMesh;
         // Add pieces to board model
         layout[piece.startPosition.x, piece.startPosition.y] = piece;
         // Connect piece to board
@@ -205,6 +217,11 @@ public class Board : MonoBehaviour
 
     GetMovesInDirection(piece, new Vector2Int(-1, (int)piece.color));
     GetMovesInDirection(piece, new Vector2Int(1, (int)piece.color));
+    if (piece.isKing)
+    {
+      GetMovesInDirection(piece, new Vector2Int(-1, -(int)piece.color));
+      GetMovesInDirection(piece, new Vector2Int(1, -(int)piece.color));
+    }
   }
 
   private void GetMovesInDirection(Piece piece, Vector2Int direction, bool jumpsOnly = false)

--- a/Assets/Scripts/Game/Piece.cs
+++ b/Assets/Scripts/Game/Piece.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 public class Piece : MonoBehaviour
 {
   public bool isActive;
+  public bool isKing;
+  public Mesh kingMesh;
   public TeamColor color;
   public Vector2Int startPosition;
   public Vector2Int currentPosition;
@@ -49,6 +51,14 @@ public class Piece : MonoBehaviour
     board = gameBoard;
   }
 
+  public void PromoteToKing()
+  {
+    this.isKing = true;
+    this.gameObject.GetComponent<MeshFilter>().mesh = kingMesh;
+
+    Debug.Log($"{gameObject.name} promoted at {currentPosition}");
+  }
+
   public bool HasValidMoves()
   {
     return (moveDestinations.Count + captureDestinations.Count) != 0;
@@ -57,6 +67,12 @@ public class Piece : MonoBehaviour
   public bool HasCaptureMoves()
   {
     return captureDestinations.Count != 0;
+  }
+
+  public bool HasReachedOppositeEndOfBoard()
+  {
+    int rowToReach = this.color == TeamColor.BLACK ? 7 : 0;
+    return this.currentPosition.y == rowToReach;
   }
 
   public void UndoMove()


### PR DESCRIPTION
**Description**
Piece promotes when it reaches opposite side of the board
When Pieces Promotes:
-Piece is able to move & capture backwards
-Piece material is changed

**Testing**
Manual Tests:

Piece reaches  end of board -> it promotes
Piece reaches end of board via capture -> It promotes
Piece reaches end of board via multi-capture -> It promotes
Piece reaches end of  board via capture and another capture is available -> It promotes and game forces player to capture
Piece is able to capture backwards when promoted -> No, unless it captured to promote  
Piece is able to capture & move backwards after promotes and a turn has passed -> Yes
Piece is able to multi-capture in all diagonal directions -> Yes

**Related Issues**
Closes #34 

**Definition of Done**

- [x] Code compiles
- [x] Code conforms to coding standards (formatted/linted)
- [x] Code is properly documented (comments, model updated)
- [x] Code has been tested and the testing method is documented in this PR
- [x] Code doesn't introduce any new bugs
- [x] Code is reviewed by at least 2 people
- [ ] GitHub branches related to the story are deleted once merged
- [x] Associated GitHub issue is updated
- [x] Kanban board is updated
